### PR TITLE
Refactor navigation structure and add resume section

### DIFF
--- a/assets/Chandar_Rathala_Resume.pdf
+++ b/assets/Chandar_Rathala_Resume.pdf
@@ -1,0 +1,40 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 282 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(Chandar Rathala | Data Analyst Resume Snapshot) Tj
+0 -28 Td
+(Download the full resume or request a tailored version at chandarrathala7@gmail.com.) Tj
+0 -28 Td
+(Highlights: Streaming analytics impact | AWS Redshift migrations | AI research leadership.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000573 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+643
+%%EOF

--- a/index.html
+++ b/index.html
@@ -18,16 +18,20 @@
         <p>Data Analyst · Streaming Impact</p>
       </div>
     </div>
-    <nav class="contact-links">
-      <a href="tel:+18134189804">+1 (813) 418-9804</a>
-      <a href="mailto:chandarrathala7@gmail.com">chandarrathala7@gmail.com</a>
-      <a href="https://www.linkedin.com/in/chandar-rathala" target="_blank" rel="noopener">LinkedIn</a>
-      <a href="https://github.com/chandarr7" target="_blank" rel="noopener">GitHub</a>
+    <nav class="main-nav" aria-label="Primary">
+      <ul class="nav-links">
+        <li><a href="#about">About</a></li>
+        <li><a href="#education">Education</a></li>
+        <li><a href="#experience">Experience</a></li>
+        <li><a href="#resume">Resume</a></li>
+        <li><a href="#portfolio">Portfolio</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
     </nav>
   </header>
 
   <main>
-    <section class="hero">
+    <section id="about" class="hero">
       <div class="hero-overlay"></div>
       <div class="hero-content">
         <p class="tagline">Now Streaming: Data-Driven Thrillers</p>
@@ -180,7 +184,7 @@
       </div>
     </section>
 
-    <section class="section experience">
+    <section id="experience" class="section experience">
       <header class="section-header">
         <p class="eyebrow">Experience Channel</p>
         <h3>Binge the Highlights</h3>
@@ -232,6 +236,28 @@
       </div>
     </section>
 
+    <section id="resume" class="section resume">
+      <header class="section-header">
+        <p class="eyebrow">Resume Hub</p>
+        <h3>Download the Feature-Length Resume</h3>
+        <p class="section-subtitle">Grab the full PDF or request a tailored cut aligned to your team's priorities.</p>
+      </header>
+      <div class="resume-body">
+        <div class="resume-summary">
+          <p>Each engagement blends technical rigor with high-impact storytelling that keeps executives and operators locked in.</p>
+          <ul class="resume-highlights">
+            <li>4+ years delivering analytics for healthcare, finance, and climate-security programs.</li>
+            <li>Trusted with AWS Redshift migrations, multi-million dollar savings, and rapid-fire BI delivery.</li>
+            <li>Graduate researcher at USF translating AI insights into policy-ready narratives.</li>
+          </ul>
+        </div>
+        <div class="resume-actions">
+          <a class="cta primary" href="assets/Chandar_Rathala_Resume.pdf" target="_blank" rel="noopener">Download PDF</a>
+          <a class="cta secondary" href="mailto:chandarrathala7@gmail.com?subject=Resume%20Request&body=Hi%20Chandar%2C%20could%20you%20share%20a%20tailored%20resume%20for%20our%20team%3F">Request a tailored version</a>
+        </div>
+      </div>
+    </section>
+
     <section class="section stats">
       <div class="section-header">
         <p class="eyebrow">Skill Matrix</p>
@@ -265,7 +291,7 @@
       </div>
     </section>
 
-    <section class="section education">
+    <section id="education" class="section education">
       <header class="section-header">
         <p class="eyebrow">Origin Story</p>
         <h3>Education</h3>

--- a/styles.css
+++ b/styles.css
@@ -84,21 +84,60 @@ main {
   font-size: 0.85rem;
 }
 
-.contact-links {
+.main-nav {
+  margin-left: auto;
   display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  font-size: 0.95rem;
+  align-items: center;
 }
 
-.contact-links a {
+.nav-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(0.75rem, 2.5vw, 1.5rem);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+}
+
+.nav-links a {
+  position: relative;
   color: var(--text-muted);
   text-decoration: none;
+  padding: 0.35rem 0;
   transition: color 0.3s ease;
 }
 
-.contact-links a:hover {
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--netflix-red);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+  opacity: 0.9;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
   color: #fff;
+}
+
+.nav-links a:hover::after,
+.nav-links a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.nav-links a:focus-visible {
+  outline: none;
 }
 
 .hero {
@@ -232,6 +271,54 @@ main {
 .section-subtitle {
   color: var(--text-muted);
   max-width: 560px;
+}
+
+.section.resume {
+  padding: clamp(2.75rem, 6vw, 4rem);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(229, 9, 20, 0.32), rgba(15, 15, 15, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 40px 90px -60px rgba(0, 0, 0, 0.9);
+}
+
+.resume-body {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.resume-summary p {
+  margin: 0 0 1.5rem;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.8;
+}
+
+.resume-highlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.resume-highlights li {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.6;
+}
+
+.resume-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.resume-actions .cta {
+  width: 100%;
+  justify-content: center;
 }
 
 .eyebrow {
@@ -657,6 +744,23 @@ main {
   text-transform: uppercase;
 }
 
+@media (min-width: 768px) {
+  .resume-body {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .resume-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1.1rem;
+  }
+
+  .resume-actions .cta {
+    width: auto;
+  }
+}
+
 @media (max-width: 1024px) {
   .carousel-control.prev {
     left: 0.25rem;
@@ -674,9 +778,10 @@ main {
     align-items: flex-start;
   }
 
-  .contact-links {
-    font-size: 0.85rem;
-    gap: 0.75rem;
+  .nav-links {
+    gap: 0.9rem;
+    font-size: 0.75rem;
+    justify-content: flex-start;
   }
 
   main {


### PR DESCRIPTION
## Summary
- replace the top contact links with a primary navigation menu that anchors to About, Education, Experience, Resume, Portfolio, and Contact sections
- tag the corresponding sections with stable IDs, introduce a resume hub with PDF/download CTAs, and surface a lightweight downloadable resume asset
- refresh styling to support the new navigation layout and resume block while maintaining the existing cinematic aesthetic

## Testing
- no tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce2799a614832aaf3a8d341258e7cc