### PR TITLE
Add chat modal trigger to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,11 +333,66 @@
       </div>
       <div class="footer-actions">
         <a class="cta primary" href="mailto:chandarrathala7@gmail.com">Contact Chandar</a>
+        <button class="cta tertiary chat-trigger" type="button" data-chat-open>
+          <span aria-hidden="true">💬</span>
+          <span>Chat with Chandar</span>
+        </button>
         <a class="cta secondary" href="https://www.linkedin.com/in/chandar-rathala" target="_blank" rel="noopener">Connect on LinkedIn</a>
       </div>
     </div>
     <p class="footer-meta">© <span id="year"></span> Chandar Rathala. Streaming excellence in data analytics.</p>
   </footer>
+
+  <div class="chat-backdrop" data-chat-overlay hidden></div>
+  <section
+    class="chat-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="chatModalTitle"
+    aria-describedby="chatModalDescription"
+    aria-hidden="true"
+    data-chat-modal
+    hidden
+  >
+    <header class="chat-modal__header">
+      <div>
+        <p class="chat-eyebrow">Live from the data studio</p>
+        <h2 id="chatModalTitle">Chat with Chandar</h2>
+      </div>
+      <button type="button" class="chat-close" data-chat-close aria-label="Close chat panel">
+        <span aria-hidden="true">×</span>
+      </button>
+    </header>
+    <p id="chatModalDescription" class="chat-modal__intro">
+      Share what you're exploring and I'll queue up insights, case studies, or custom dashboards on demand.
+    </p>
+    <div class="chat-modal__body">
+      <a
+        class="chat-option"
+        href="mailto:chandarrathala7@gmail.com?subject=Let%27s%20chat%20about%20data"
+        data-autofocus
+      >
+        <span class="chat-option__icon" aria-hidden="true">📧</span>
+        <span class="chat-option__content">
+          <strong>Email the studio</strong>
+          <small>Send a note and I'll respond faster than the next episode drops.</small>
+        </span>
+      </a>
+      <a class="chat-option" href="https://www.linkedin.com/in/chandar-rathala" target="_blank" rel="noopener">
+        <span class="chat-option__icon" aria-hidden="true">💼</span>
+        <span class="chat-option__content">
+          <strong>Connect on LinkedIn</strong>
+          <small>DM me for collaboration ideas or portfolio deep-dives.</small>
+        </span>
+      </a>
+    </div>
+    <footer class="chat-modal__footer">
+      <p>
+        Prefer scheduling?
+        <a href="mailto:chandarrathala7@gmail.com?subject=Book%20a%20data%20chat">Request a meeting slot.</a>
+      </p>
+    </footer>
+  </section>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -45,3 +45,84 @@ carousels.forEach((carousel) => {
   window.addEventListener('resize', toggleControls);
   toggleControls();
 });
+
+const chatModal = document.querySelector('[data-chat-modal]');
+const chatOverlay = document.querySelector('[data-chat-overlay]');
+const chatOpeners = document.querySelectorAll('[data-chat-open]');
+const chatCloseBtn = document.querySelector('[data-chat-close]');
+
+if (chatModal && chatOverlay) {
+  const focusableSelector =
+    'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  let lastFocusedElement = null;
+  const transitionDuration = 300;
+
+  const openChat = () => {
+    if (chatModal.classList.contains('is-visible')) return;
+
+    lastFocusedElement = document.activeElement;
+    chatModal.hidden = false;
+    chatOverlay.hidden = false;
+    chatModal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('is-chat-open');
+
+    requestAnimationFrame(() => {
+      chatModal.classList.add('is-visible');
+      chatOverlay.classList.add('is-visible');
+      const focusTarget =
+        chatModal.querySelector('[data-autofocus]') || chatModal.querySelector(focusableSelector);
+      focusTarget?.focus({ preventScroll: true });
+    });
+  };
+
+  const closeChat = () => {
+    if (!chatModal.classList.contains('is-visible')) return;
+
+    chatModal.classList.remove('is-visible');
+    chatOverlay.classList.remove('is-visible');
+    chatModal.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('is-chat-open');
+
+    window.setTimeout(() => {
+      chatModal.hidden = true;
+      chatOverlay.hidden = true;
+      if (lastFocusedElement instanceof HTMLElement) {
+        lastFocusedElement.focus({ preventScroll: true });
+      }
+      lastFocusedElement = null;
+    }, transitionDuration);
+  };
+
+  chatOpeners.forEach((opener) => opener.addEventListener('click', openChat));
+  chatCloseBtn?.addEventListener('click', closeChat);
+  chatOverlay.addEventListener('click', closeChat);
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && chatModal.classList.contains('is-visible')) {
+      closeChat();
+    }
+  });
+
+  chatModal.addEventListener('keydown', (event) => {
+    if (event.key !== 'Tab' || !chatModal.classList.contains('is-visible')) {
+      return;
+    }
+
+    const focusable = Array.from(chatModal.querySelectorAll(focusableSelector)).filter(
+      (element) => !element.hasAttribute('disabled') && element.getAttribute('tabindex') !== '-1'
+    );
+
+    if (!focusable.length) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,10 @@ body {
   scroll-behavior: smooth;
 }
 
+body.is-chat-open {
+  overflow: hidden;
+}
+
 a {
   color: inherit;
 }
@@ -216,9 +220,34 @@ main {
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+.cta.tertiary {
+  background: rgba(229, 9, 20, 0.1);
+  color: #fff;
+  border: 1px solid rgba(229, 9, 20, 0.4);
+  box-shadow: 0 18px 40px -28px rgba(229, 9, 20, 0.7);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.cta.chat-trigger {
+  position: relative;
+  overflow: hidden;
+}
+
+.cta.chat-trigger span[aria-hidden='true'] {
+  font-size: 1.1rem;
+  filter: drop-shadow(0 0 6px rgba(229, 9, 20, 0.75));
+}
+
 .cta:hover {
   transform: translateY(-2px);
   box-shadow: 0 30px 50px -30px rgba(229, 9, 20, 0.6);
+}
+
+.cta:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.65), 0 20px 45px -25px rgba(229, 9, 20, 0.6);
+  transform: translateY(-1px);
 }
 
 .hero-highlights {
@@ -744,6 +773,183 @@ main {
   text-transform: uppercase;
 }
 
+.chat-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 7, 9, 0.82);
+  backdrop-filter: blur(6px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 200;
+}
+
+.chat-backdrop.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.chat-modal {
+  position: fixed;
+  right: clamp(1.5rem, 6vw, 3.5rem);
+  bottom: clamp(1.5rem, 6vw, 3.5rem);
+  width: min(420px, calc(100vw - 2.5rem));
+  padding: 1.75rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(160deg, rgba(22, 22, 24, 0.98), rgba(8, 8, 10, 0.96));
+  border: 1px solid rgba(229, 9, 20, 0.35);
+  box-shadow: 0 45px 85px -45px rgba(0, 0, 0, 0.95);
+  opacity: 0;
+  transform: translate3d(0, 2rem, 0);
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 205;
+  display: grid;
+  gap: 1.35rem;
+}
+
+.chat-modal.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  pointer-events: auto;
+}
+
+.chat-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.chat-modal__header h2 {
+  margin: 0.35rem 0 0;
+  font-family: 'Oswald', 'Roboto', sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 1.6rem;
+}
+
+.chat-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.chat-modal__intro {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.6;
+}
+
+.chat-modal__body {
+  display: grid;
+  gap: 1rem;
+}
+
+.chat-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.25s ease, border-color 0.25s ease, background-color 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.chat-option:hover {
+  transform: translateY(-2px);
+  border-color: rgba(229, 9, 20, 0.5);
+  background: rgba(229, 9, 20, 0.18);
+  box-shadow: 0 25px 45px -35px rgba(229, 9, 20, 0.6);
+}
+
+.chat-option:focus-visible {
+  outline: none;
+  border-color: rgba(229, 9, 20, 0.75);
+  box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.35), 0 25px 45px -30px rgba(229, 9, 20, 0.65);
+}
+
+.chat-option__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: rgba(229, 9, 20, 0.2);
+  font-size: 1.35rem;
+}
+
+.chat-option__content strong {
+  display: block;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+}
+
+.chat-option__content small {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.chat-modal__footer {
+  margin: 0;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.58);
+  letter-spacing: 0.05em;
+}
+
+.chat-modal__footer a {
+  color: #fff;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(229, 9, 20, 0.4);
+}
+
+.chat-modal__footer a:hover,
+.chat-modal__footer a:focus-visible {
+  color: var(--netflix-red);
+  border-bottom-color: rgba(229, 9, 20, 0.7);
+}
+
+.chat-close {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.chat-close span {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.chat-close:hover {
+  transform: scale(1.05);
+  background: rgba(229, 9, 20, 0.3);
+  border-color: rgba(229, 9, 20, 0.5);
+}
+
+.chat-close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.55);
+}
+
 @media (min-width: 768px) {
   .resume-body {
     grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
@@ -758,6 +964,51 @@ main {
 
   .resume-actions .cta {
     width: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .chat-modal {
+    right: clamp(1rem, 5vw, 2.25rem);
+    bottom: clamp(1.25rem, 7vw, 3rem);
+    width: min(360px, calc(100vw - 2rem));
+  }
+}
+
+@media (max-width: 640px) {
+  .footer-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .footer-actions .cta {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}
+
+@media (max-width: 560px) {
+  .chat-modal {
+    left: 50%;
+    right: auto;
+    width: min(420px, calc(100vw - 1.5rem));
+    transform: translate(-50%, 2rem);
+  }
+
+  .chat-modal.is-visible {
+    transform: translate(-50%, 0);
+  }
+}
+
+@media (max-width: 420px) {
+  .chat-option {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-option__icon {
+    width: 36px;
+    height: 36px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a "Chat with Chandar" call-to-action to the footer alongside existing contact links
- wire up a new chat modal with keyboard-friendly open/close controls and focus management in `script.js`
- extend the styling system for the chat trigger and modal, aligning with the Netflix-inspired theme and responsive layout tweaks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce2afdf4e8832aa8d4e3674b1740d5