### PR TITLE
Add contact form and client-side feedback to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,14 +327,30 @@
 
   <footer id="contact" class="footer">
     <div class="footer-content">
-      <div>
+      <div class="footer-intro">
         <h4>Ready for the next season?</h4>
         <p>Let’s collaborate on data narratives that keep decision-makers on the edge of their seats.</p>
+        <div class="footer-actions">
+          <a class="cta primary" href="mailto:chandarrathala7@gmail.com">Contact Chandar</a>
+          <a class="cta secondary" href="https://www.linkedin.com/in/chandar-rathala" target="_blank" rel="noopener">Connect on LinkedIn</a>
+        </div>
       </div>
-      <div class="footer-actions">
-        <a class="cta primary" href="mailto:chandarrathala7@gmail.com">Contact Chandar</a>
-        <a class="cta secondary" href="https://www.linkedin.com/in/chandar-rathala" target="_blank" rel="noopener">Connect on LinkedIn</a>
-      </div>
+      <form class="contact-form" id="contact-form" novalidate>
+        <div class="form-field">
+          <label for="full-name">Full Name</label>
+          <input type="text" id="full-name" name="fullName" autocomplete="name" required />
+        </div>
+        <div class="form-field">
+          <label for="email">Email Address</label>
+          <input type="email" id="email" name="email" autocomplete="email" required />
+        </div>
+        <div class="form-field">
+          <label for="message">Message</label>
+          <textarea id="message" name="message" rows="4" autocomplete="off" required></textarea>
+        </div>
+        <button type="submit" class="cta primary submit-button">Send Message</button>
+        <p class="form-status" data-status role="status" aria-live="polite"></p>
+      </form>
     </div>
     <p class="footer-meta">© <span id="year"></span> Chandar Rathala. Streaming excellence in data analytics.</p>
   </footer>

--- a/script.js
+++ b/script.js
@@ -45,3 +45,71 @@ carousels.forEach((carousel) => {
   window.addEventListener('resize', toggleControls);
   toggleControls();
 });
+
+const contactForm = document.getElementById('contact-form');
+
+if (contactForm) {
+  const statusEl = contactForm.querySelector('[data-status]');
+  const submitButton = contactForm.querySelector('button[type="submit"]');
+  const nameInput = contactForm.querySelector('[name="fullName"]');
+  const emailInput = contactForm.querySelector('[name="email"]');
+  const messageInput = contactForm.querySelector('[name="message"]');
+
+  const setStatus = (message, state) => {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.classList.remove('is-error', 'is-success', 'is-pending');
+    if (state) {
+      statusEl.classList.add(`is-${state}`);
+    }
+  };
+
+  [nameInput, emailInput, messageInput].forEach((input) => {
+    input?.addEventListener('input', () => setStatus('', null));
+  });
+
+  contactForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(contactForm);
+    const fullName = (formData.get('fullName') || '').toString().trim();
+    const email = (formData.get('email') || '').toString().trim();
+    const message = (formData.get('message') || '').toString().trim();
+
+    if (!fullName) {
+      setStatus('Please share your name so I know who is reaching out.', 'error');
+      nameInput?.focus();
+      return;
+    }
+
+    if (!email) {
+      setStatus('Please provide an email address so I can respond.', 'error');
+      emailInput?.focus();
+      return;
+    }
+
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(email)) {
+      setStatus('Enter a valid email address so I can reach you back.', 'error');
+      emailInput?.focus();
+      return;
+    }
+
+    if (!message) {
+      setStatus('Let me know how I can help by adding a quick message.', 'error');
+      messageInput?.focus();
+      return;
+    }
+
+    setStatus('Sending…', 'pending');
+    submitButton?.setAttribute('disabled', 'true');
+    submitButton?.setAttribute('aria-busy', 'true');
+
+    window.setTimeout(() => {
+      contactForm.reset();
+      setStatus('Thanks for reaching out! I’ll respond as soon as possible.', 'success');
+      submitButton?.removeAttribute('disabled');
+      submitButton?.removeAttribute('aria-busy');
+    }, 700);
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -713,9 +713,13 @@ main {
 .footer-content {
   max-width: var(--max-width);
   margin: 0 auto 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.footer-intro {
+  display: grid;
+  gap: 1.25rem;
 }
 
 .footer-content h4 {
@@ -734,6 +738,90 @@ main {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+}
+
+.contact-form {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 35px 70px -60px rgba(0, 0, 0, 0.9);
+}
+
+.form-field {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.contact-form label {
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(7, 7, 9, 0.7);
+  color: var(--text-light);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.contact-form input::placeholder,
+.contact-form textarea::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.contact-form input:focus-visible,
+.contact-form textarea:focus-visible {
+  outline: none;
+  border-color: var(--netflix-red);
+  box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.25);
+  background: rgba(7, 7, 9, 0.85);
+}
+
+.contact-form textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.contact-form .submit-button {
+  border: none;
+  cursor: pointer;
+  align-self: flex-start;
+  justify-content: center;
+}
+
+.contact-form .submit-button[disabled] {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.form-status {
+  min-height: 1.2em;
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.form-status.is-error {
+  color: #ff6b6b;
+}
+
+.form-status.is-success {
+  color: #4ade80;
+}
+
+.form-status.is-pending {
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .footer-meta {
@@ -757,6 +845,15 @@ main {
   }
 
   .resume-actions .cta {
+    width: auto;
+  }
+
+  .footer-content {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .contact-form .submit-button {
     width: auto;
   }
 }
@@ -794,6 +891,10 @@ main {
 
   .poster-card {
     min-width: clamp(220px, 70vw, 280px);
+  }
+
+  .contact-form .submit-button {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- embed an accessible contact form in the contact footer with fields for name, email, and message plus a status region
- style the new form layout, controls, and button to complement the existing dark theme and remain responsive
- add client-side validation with simulated submission feedback so visitors receive messaging while backend integration is pending

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce2b0235a4832abcb265fa28fecba8