### PR TITLE
Relocate portfolio content into featured projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         <h2>Transforming raw numbers into binge-worthy decisions.</h2>
         <p class="summary">Data Analyst with 4+ years of experience powering healthcare, finance, and climate-security adventures. Expert in SQL, Python, BI, and cloud warehousing with a track record of reducing costs, accelerating insights, and building reliable data products.</p>
         <div class="hero-actions">
-          <a class="cta primary" href="#portfolio">▶ Play Career</a>
+          <a class="cta primary" href="#featured-projects">▶ Play Career</a>
           <a class="cta secondary" href="#contact">+ Add to Watchlist</a>
         </div>
         <dl class="hero-highlights">
@@ -54,7 +54,7 @@
       </div>
     </section>
 
-    <section id="portfolio" class="section portfolio">
+    <section id="featured-projects" class="section pop-hub">
       <header class="section-header">
         <p class="eyebrow">Now Streaming</p>
         <h3>Portfolio</h3>
@@ -80,103 +80,103 @@
           <a class="portfolio-link" href="https://www.novypro.com/project/business-insights-360" target="_blank" rel="noopener">View Project</a>
         </article>
       </div>
-    </section>
 
-    <section id="featured-projects" class="section">
-      <header class="section-header">
-        <p class="eyebrow">Featured Missions</p>
-        <h3>Original Productions</h3>
-        <p class="section-subtitle">Projects engineered to keep stakeholders glued to their dashboards.</p>
-      </header>
+      <div class="featured-reel">
+        <header class="section-header subheader">
+          <p class="eyebrow">Featured Missions</p>
+          <h3>Original Productions</h3>
+          <p class="section-subtitle">Projects engineered to keep stakeholders glued to their dashboards.</p>
+        </header>
 
-      <div class="carousel" data-carousel>
-        <button class="carousel-control prev" data-action="prev" aria-label="Scroll previous">
-          <span>‹</span>
-        </button>
-        <div class="carousel-track" role="list">
-          <article class="poster-card" role="listitem">
-            <div class="poster-top">
-              <span class="category">Analytics Saga</span>
-              <span class="runtime">2025 · Power BI · SQL</span>
-            </div>
-            <div class="poster-content">
-              <h4>Business 360: E-commerce Sales Analytics</h4>
-              <p>Multi-tab Power BI universe unifying product, customer, and forecasting insights for decisive pricing and growth strategies.</p>
-              <div class="poster-meta">
-                <span class="badge">Forecasting</span>
-                <span class="badge">Segmentation</span>
+        <div class="carousel" data-carousel>
+          <button class="carousel-control prev" data-action="prev" aria-label="Scroll previous">
+            <span>‹</span>
+          </button>
+          <div class="carousel-track" role="list">
+            <article class="poster-card" role="listitem">
+              <div class="poster-top">
+                <span class="category">Analytics Saga</span>
+                <span class="runtime">2025 · Power BI · SQL</span>
               </div>
-              <a class="watch-trailer" href="#">Watch Trailer</a>
-            </div>
-          </article>
-
-          <article class="poster-card" role="listitem">
-            <div class="poster-top">
-              <span class="category">People Ops Drama</span>
-              <span class="runtime">2024 · Power BI · ETL</span>
-            </div>
-            <div class="poster-content">
-              <h4>HR Analysis Dashboard</h4>
-              <p>Attrition forecasting and workforce pulse tracking with 35% faster refresh rates and airtight data quality controls.</p>
-              <div class="poster-meta">
-                <span class="badge">Attrition</span>
-                <span class="badge">Data Quality</span>
+              <div class="poster-content">
+                <h4>Business 360: E-commerce Sales Analytics</h4>
+                <p>Multi-tab Power BI universe unifying product, customer, and forecasting insights for decisive pricing and growth strategies.</p>
+                <div class="poster-meta">
+                  <span class="badge">Forecasting</span>
+                  <span class="badge">Segmentation</span>
+                </div>
+                <a class="watch-trailer" href="#">Watch Trailer</a>
               </div>
-              <a class="watch-trailer" href="#">Watch Trailer</a>
-            </div>
-          </article>
+            </article>
 
-          <article class="poster-card" role="listitem">
-            <div class="poster-top">
-              <span class="category">Smart City Thriller</span>
-              <span class="runtime">2024 · React · PostgreSQL</span>
-            </div>
-            <div class="poster-content">
-              <h4>USF Parking Tracker</h4>
-              <p>Real-time parking intelligence with geospatial heatmaps, Azure deployment, and analytics dashboards for operational optimization.</p>
-              <div class="poster-meta">
-                <span class="badge">Geospatial</span>
-                <span class="badge">Real-time</span>
+            <article class="poster-card" role="listitem">
+              <div class="poster-top">
+                <span class="category">People Ops Drama</span>
+                <span class="runtime">2024 · Power BI · ETL</span>
               </div>
-              <a class="watch-trailer" href="#">Watch Trailer</a>
-            </div>
-          </article>
+              <div class="poster-content">
+                <h4>HR Analysis Dashboard</h4>
+                <p>Attrition forecasting and workforce pulse tracking with 35% faster refresh rates and airtight data quality controls.</p>
+                <div class="poster-meta">
+                  <span class="badge">Attrition</span>
+                  <span class="badge">Data Quality</span>
+                </div>
+                <a class="watch-trailer" href="#">Watch Trailer</a>
+              </div>
+            </article>
 
-          <article class="poster-card" role="listitem">
-            <div class="poster-top">
-              <span class="category">Security Sci-Fi</span>
-              <span class="runtime">2021 · Python · Django</span>
-            </div>
-            <div class="poster-content">
-              <h4>Blockchain E-Voting System</h4>
-              <p>Prototype election platform using blockchain principles to deliver transparent, tamper-resistant ballot simulations.</p>
-              <div class="poster-meta">
-                <span class="badge">Blockchain</span>
-                <span class="badge">Security</span>
+            <article class="poster-card" role="listitem">
+              <div class="poster-top">
+                <span class="category">Smart City Thriller</span>
+                <span class="runtime">2024 · React · PostgreSQL</span>
               </div>
-              <a class="watch-trailer" href="#">Watch Trailer</a>
-            </div>
-          </article>
+              <div class="poster-content">
+                <h4>USF Parking Tracker</h4>
+                <p>Real-time parking intelligence with geospatial heatmaps, Azure deployment, and analytics dashboards for operational optimization.</p>
+                <div class="poster-meta">
+                  <span class="badge">Geospatial</span>
+                  <span class="badge">Real-time</span>
+                </div>
+                <a class="watch-trailer" href="#">Watch Trailer</a>
+              </div>
+            </article>
 
-          <article class="poster-card" role="listitem">
-            <div class="poster-top">
-              <span class="category">AI Feature</span>
-              <span class="runtime">2022 · Computer Vision</span>
-            </div>
-            <div class="poster-content">
-              <h4>Facial Recognition with AI</h4>
-              <p>Biometric experiment surpassing 90% accuracy on limited data, showcasing rapid model iteration and validation rigor.</p>
-              <div class="poster-meta">
-                <span class="badge">Computer Vision</span>
-                <span class="badge">Model Validation</span>
+            <article class="poster-card" role="listitem">
+              <div class="poster-top">
+                <span class="category">Security Sci-Fi</span>
+                <span class="runtime">2021 · Python · Django</span>
               </div>
-              <a class="watch-trailer" href="#">Watch Trailer</a>
-            </div>
-          </article>
+              <div class="poster-content">
+                <h4>Blockchain E-Voting System</h4>
+                <p>Prototype election platform using blockchain principles to deliver transparent, tamper-resistant ballot simulations.</p>
+                <div class="poster-meta">
+                  <span class="badge">Blockchain</span>
+                  <span class="badge">Security</span>
+                </div>
+                <a class="watch-trailer" href="#">Watch Trailer</a>
+              </div>
+            </article>
+
+            <article class="poster-card" role="listitem">
+              <div class="poster-top">
+                <span class="category">AI Feature</span>
+                <span class="runtime">2022 · Computer Vision</span>
+              </div>
+              <div class="poster-content">
+                <h4>Facial Recognition with AI</h4>
+                <p>Biometric experiment surpassing 90% accuracy on limited data, showcasing rapid model iteration and validation rigor.</p>
+                <div class="poster-meta">
+                  <span class="badge">Computer Vision</span>
+                  <span class="badge">Model Validation</span>
+                </div>
+                <a class="watch-trailer" href="#">Watch Trailer</a>
+              </div>
+            </article>
+          </div>
+          <button class="carousel-control next" data-action="next" aria-label="Scroll next">
+            <span>›</span>
+          </button>
         </div>
-        <button class="carousel-control next" data-action="next" aria-label="Scroll next">
-          <span>›</span>
-        </button>
       </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -241,7 +241,7 @@ main {
   color: var(--netflix-red);
 }
 
-.section.portfolio {
+.pop-hub {
   position: relative;
   padding: clamp(2.5rem, 5vw, 3.75rem);
   border-radius: var(--radius-lg);
@@ -251,13 +251,18 @@ main {
   overflow: hidden;
 }
 
-.section.portfolio::after {
+.pop-hub::after {
   content: "";
   position: absolute;
   inset: 0;
   background: radial-gradient(circle at 20% 80%, rgba(229, 9, 20, 0.18), transparent 55%);
   pointer-events: none;
   mix-blend-mode: screen;
+}
+
+.pop-hub > * {
+  position: relative;
+  z-index: 1;
 }
 
 .portfolio-grid {
@@ -353,6 +358,15 @@ main {
 .portfolio-link:hover {
   background: rgba(229, 9, 20, 0.3);
   transform: translateY(-2px);
+}
+
+.featured-reel {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+}
+
+.section-header.subheader {
+  gap: 0.35rem;
 }
 
 .carousel {


### PR DESCRIPTION
## Summary
- merge the standalone portfolio cards into the featured projects hub and remove the redundant section
- retarget the hero CTA to scroll to the new featured projects anchor
- refresh styles so the shared featured layout carries the pop treatment while dropping unused portfolio container rules

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce26d6f494832a84c28a13e68653b4